### PR TITLE
Disable SonarQube scan until SonarCloud is configured

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,11 @@ jobs:
 
       - name: Run Rubocop
         run: make lint
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # NOTE: uncomment for use it
+      # Requires a SonarCloud project, a valid SONAR_TOKEN secret
+      # and a sonar-project.properties file with sonar.projectKey and sonar.organization
+      # - name: SonarQube Scan
+        # uses: SonarSource/sonarqube-scan-action@v8
+        # env:
+          # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Why

CI in this repo has never been green — every run (including pushes to `main`) fails on the SonarQube Scan step:

- PR runs fail with `You must define the following mandatory properties: sonar.projectKey, sonar.organization` — there is no `sonar-project.properties` in the repo;
- pushes to `main` fail with `HTTP 403 Forbidden ... check the property sonar.token or the environment variable SONAR_TOKEN` — the secret is not set up.

This also keeps every dependabot PR permanently red (e.g. #9).

## What

Comment the scan step out the same way `php-package` does, with a note on what is required to re-enable it (SonarCloud project, `SONAR_TOKEN` secret, `sonar-project.properties` with `sonar.projectKey`/`sonar.organization`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)